### PR TITLE
Support more emsdk versions

### DIFF
--- a/.idea/fileTemplates/includes/skia-benchmark File Header.h
+++ b/.idea/fileTemplates/includes/skia-benchmark File Header.h
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2024 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (C) 2025 Tencent.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,30 @@ in your default browser. You can also open it manually to view the demo.
 
 The above commands build and run a multithreaded version.
 
+>**⚠️** In the multithreaded version, if you modify the filename of the compiled output benchmark.js, you need to search for
+> the keyword "benchmark.js" within the benchmark.js file and replace all occurrences of "benchmark.js" with the new filename.
+> Failure to do this will result in the program failing to run. Here's an example of how to modify it:
+
+Before modification:
+
+```js
+    // filename: benchmark.js
+    var worker = new Worker(new URL("benchmark.js", import.meta.url), {
+     type: "module",
+     name: "em-pthread"
+    });
+```
+
+After modification:
+
+```js
+    // filename: benchmark-test.js
+    var worker = new Worker(new URL("benchmark-test.js", import.meta.url), {
+     type: "module",
+     name: "em-pthread"
+    });
+```
+
 To build a single-threaded version, just add the suffix ":st" to each command. For example:
 
 ```

--- a/src/base/AppHost.cpp
+++ b/src/base/AppHost.cpp
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/base/AppHost.h
+++ b/src/base/AppHost.h
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/base/Bench.cpp
+++ b/src/base/Bench.cpp
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/base/Bench.h
+++ b/src/base/Bench.h
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/benchmark/ParticleBench.cpp
+++ b/src/benchmark/ParticleBench.cpp
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/benchmark/ParticleBench.h
+++ b/src/benchmark/ParticleBench.h
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/mac/AppDelegate.h
+++ b/src/platform/mac/AppDelegate.h
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/mac/AppDelegate.mm
+++ b/src/platform/mac/AppDelegate.mm
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/mac/GLWindowContext_mac.h
+++ b/src/platform/mac/GLWindowContext_mac.h
@@ -1,7 +1,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/mac/GLWindowContext_mac.mm
+++ b/src/platform/mac/GLWindowContext_mac.mm
@@ -1,7 +1,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/mac/SkiaWindow.h
+++ b/src/platform/mac/SkiaWindow.h
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/mac/SkiaWindow.mm
+++ b/src/platform/mac/SkiaWindow.mm
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/mac/main.mm
+++ b/src/platform/mac/main.mm
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/win/GLWindowContext_win.cpp
+++ b/src/platform/win/GLWindowContext_win.cpp
@@ -1,7 +1,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/win/GLWindowContext_win.h
+++ b/src/platform/win/GLWindowContext_win.h
@@ -1,7 +1,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/win/SkiaWindow.cpp
+++ b/src/platform/win/SkiaWindow.cpp
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/win/SkiaWindow.h
+++ b/src/platform/win/SkiaWindow.h
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/win/WGLInterface.cpp
+++ b/src/platform/win/WGLInterface.cpp
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/win/WGLInterface.h
+++ b/src/platform/win/WGLInterface.h
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/win/WGLUtil.cpp
+++ b/src/platform/win/WGLUtil.cpp
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/win/WGLUtil.h
+++ b/src/platform/win/WGLUtil.h
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/platform/win/main.cpp
+++ b/src/platform/win/main.cpp
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/tools/Clock.cpp
+++ b/src/tools/Clock.cpp
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/tools/Clock.h
+++ b/src/tools/Clock.h
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/window_context/DisplayParams.h
+++ b/src/window_context/DisplayParams.h
@@ -1,7 +1,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/window_context/GLWindowContext.h
+++ b/src/window_context/GLWindowContext.h
@@ -1,7 +1,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/window_context/WindowContext.cpp
+++ b/src/window_context/WindowContext.cpp
@@ -1,7 +1,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/src/window_context/WindowContext.h
+++ b/src/window_context/WindowContext.h
@@ -1,7 +1,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/web/demo/CMakeLists.txt
+++ b/web/demo/CMakeLists.txt
@@ -31,14 +31,15 @@ if (DEFINED EMSCRIPTEN)
     list(APPEND BENCHMARK_COMPILE_OPTIONS -fno-rtti -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0)
     list(APPEND BENCHMARK_LINK_OPTIONS --no-entry -lembind -fno-rtti -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0 -sEXPORT_NAME='Benchmark' -sWASM=1 -sASYNCIFY
             -sMAX_WEBGL_VERSION=2 -sEXPORTED_RUNTIME_METHODS=['GL','HEAPU8'] -sEXPORTED_FUNCTIONS=['_main'] -sMODULARIZE=1
-            -sENVIRONMENT='web,worker' -sEXPORT_ES6=1 -sASSERTIONS=2 -sDISABLE_EXCEPTION_CATCHING=0
+            -sENVIRONMENT=web,worker -sEXPORT_ES6=1 -sASSERTIONS=2 -sDISABLE_EXCEPTION_CATCHING=0
             -sDISABLE_EXCEPTION_CATCHING -sNODEJS_CATCH_EXIT=0 -sDYNAMIC_EXECUTION=0 -sFORCE_FILESYSTEM=0 -sFILESYSTEM=0
     )
-    if (${EMSCRIPTEN_VERSION} VERSION_LESS "4.0.4")
-        list(APPEND BENCHMARK_LINK_OPTIONS -sUSE_ES6_IMPORT_META=0)
-    elseif (${EMSCRIPTEN_VERSION} VERSION_GREATER_EQUAL "4.0.4" AND ${EMSCRIPTEN_VERSION} VERSION_LESS "4.0.6")
-        message(FATAL_ERROR "Emscripten version ${EMSCRIPTEN_VERSION} is not supported. Please upgrade to 4.0.6 or higher.")
-    endif ()
+    set(unsupported_emsdk_versions "4.0.11")
+    foreach (unsupported_version IN LISTS unsupported_emsdk_versions)
+        if (${EMSCRIPTEN_VERSION} VERSION_EQUAL ${unsupported_version})
+            message(FATAL_ERROR "Emscripten version ${EMSCRIPTEN_VERSION} is not supported.")
+        endif ()
+    endforeach ()
     if (EMSCRIPTEN_PTHREADS)
         list(APPEND BENCHMARK_LINK_OPTIONS -sUSE_PTHREADS=1 -sINITIAL_MEMORY=32MB -sALLOW_MEMORY_GROWTH=1
                 -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency -sPROXY_TO_PTHREAD=1

--- a/web/demo/common.ts
+++ b/web/demo/common.ts
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/web/demo/index-st.html
+++ b/web/demo/index-st.html
@@ -13,6 +13,6 @@
 <div id="container" class="container">
     <canvas class="canvas" id="benchmark"></canvas>
 </div>
-<script type="module" src="./index-st.js"></script>
+<script type="module" src="./wasm/index-st.js"></script>
 </body>
 </html>

--- a/web/demo/index-st.ts
+++ b/web/demo/index-st.ts
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/web/demo/index.html
+++ b/web/demo/index.html
@@ -13,6 +13,6 @@
 <div id="container" class="container">
     <canvas class="canvas" id="benchmark"></canvas>
 </div>
-<script type="module" src="./index.js"></script>
+<script type="module" src="./wasm-mt/index.js"></script>
 </body>
 </html>

--- a/web/demo/index.ts
+++ b/web/demo/index.ts
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/web/demo/src/SkiaView.cpp
+++ b/web/demo/src/SkiaView.cpp
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/web/demo/src/SkiaView.h
+++ b/web/demo/src/SkiaView.h
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/web/demo/src/binding.cpp
+++ b/web/demo/src/binding.cpp
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making skia-benchmark available.
 //
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at

--- a/web/script/rollup.demo.js
+++ b/web/script/rollup.demo.js
@@ -2,34 +2,31 @@ import esbuild from 'rollup-plugin-esbuild';
 import resolve from '@rollup/plugin-node-resolve';
 import commonJs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
+import path from "path";
+import {readFileSync} from "node:fs";
 
-const banner = `/////////////////////////////////////////////////////////////////////////////////////////////////
-//
-//  Tencent is pleased to support the open source community by making skia-benchmark available.
-//
-//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
-//
-//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
-//  in compliance with the License. You may obtain a copy of the License at
-//
-//      https://opensource.org/licenses/BSD-3-Clause
-//
-//  unless required by applicable law or agreed to in writing, software distributed under the
-//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
-//  either express or implied. see the license for the specific language governing permissions
-//  and limitations under the license.
-//
-/////////////////////////////////////////////////////////////////////////////////////////////////
-`;
+const fileHeaderPath = path.resolve(__dirname, '../../.idea/fileTemplates/includes/skia-benchmark File Header.h');
+const banner = readFileSync(fileHeaderPath, 'utf-8');
 
 const arch = process.env.ARCH;
 var fileName = (arch === 'wasm-mt'? 'index': 'index-st');
+var filePath = (arch === 'wasm-mt'? 'wasm-mt': 'wasm');
 
 const plugins = [
     esbuild({tsconfig: "tsconfig.json", minify: false}),
     json(),
     resolve(),
     commonJs(),
+    {
+        name: 'preserve-import-meta-url',
+        resolveImportMeta(property, options) {
+            // Preserve the original behavior of `import.meta.url`.
+            if (property === 'url') {
+                return 'import.meta.url';
+            }
+            return null;
+        },
+    },
 ];
 
 export default [
@@ -37,7 +34,7 @@ export default [
         input: `demo/${fileName}.ts`,
         output: {
             banner,
-            file: `demo/${fileName}.js`,
+            file: `demo/${filePath}/${fileName}.js`,
             format: 'esm',
             sourcemap: true
         },


### PR DESCRIPTION
1、使用emsdk编译web时默认开启import.meta，并针对import.meta做兼容性适配
2、添加emsdk版本检查，遇到不支持的版本时结束构建
3、添加LICENSE文件，更新许可证引用